### PR TITLE
Feature add support for markdown and mentioned people in /messages POSTs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.env*

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .env*
+test-cases/spark_emulator_tests.postman_environment.json

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Therefore, the emulator mimics Cisco Spark REST API behavior for /rooms, /messag
 The following features are NOT implemented: Messages Attachements, Room moderation, People LastActivity & Status and Pagination, as well as Teams, Automatic Invitations (if non Spark users are added to rooms) and Administration APIs, 
 
 The emulator can be used for several purposes:
-- testing: on a developer laptop machine or on a CI environment to run a battery of test with no connection to Cisco Spark, and without 409 (Rate Limitations),
+- testing: on a developer laptop machine or on a CI environment to run a battery of test with no connection to Cisco Spark, and without 409 (Rate Limitations)
 - QA: run your code against a stable version of Cisco Spark (as the Cloud Service is incrementally upgraded, some bugs can be hard to replay. The emulator complies with a version of the API at a specific date, and helps reproduce an issue, or test for an upcoming feature (not released yet or toggled on)
+- Bot Regression testing:  Create a set of regression tests to ensure that for given user inputs you will get expected bot responses.   See [Bot Testing Mode](#Bot-Testing-Mode) below.
 - Training: backup plan in case of low or no connectivity location
 - QA: simulate specific behaviors or errors from CiscoSpark (429, 500, 503)
-
 
 ## Give it a try from Heroku
 
@@ -50,13 +50,79 @@ DEBUG="emulator*" node server.js
    - POST /rooms               create a new room
    - POST /rooms               create another room
    - GET  /rooms               shows your rooms (2)
+   - DELETE /rooms:id          deletes a room
    - POST /memberships         add a bot to the room
    - POST /memberships         409 (conflict)
    - GET  /memberships         show all your memberships
    - GET  /memberships?room=   fetch memberships for you and your bot in current room
-   - POST /messages            create a new message
+   - DELETE /memberships
+   - POST /messages            create a new message.  If the payload includes a personId, will create a new one on one space if one does not already exist.  (personEmail not yet supported)
    - POST /webhooks            register a new webhook pointing to a target URL on your local machine, or on the internet
+   - DELETE /webhooks/:id      deletes a webhook
 
+## Bot Testing Mode
+  The emultator can be run in a special mode for bot testing by running with the environment variable BOT_UNDER_TEST set to the email of a user specified in tokens.json.   When this environment variable is set additional middleware is loaded the performs that following functions:
+  - Inspect all incoming requests for an X-Bot-Responses header.  When found it will intercept the response that normally would be sent to the caller of the API
+  - Inspect all incoming requests from the BOT_UNDER_TEST.  When found the system checks to see if the bot request is correlated to any prior requests with the X-Bot-Response header.   Generally correlation is done using the roomID.   
+  - When correlated Bot responses are found, the emulator will build a new response body that will contain the response body to the original request in an object called testFrameworkResponse, as well as an array of botResponse objects that occured in response to the test input.   Each botResponse object will contain the request sent by the Bot.  The number of botResponse objects collected is the value specified in the X-Bot-Responses header.   
+
+  As an example if we may expect a bot to send a message in response to being added to a space, and then to leave the space.  To validate this with a test we would write a test that adds the bot to a space using the /memberships endpoint, which also set an X-Bot-Response header to 2, ie:
+```
+POST http://localhost:3210/memberships
+{
+    "headers" {
+        "x-bot-responses": "2",
+        ... 
+    },
+    "body" {
+        "roomId": "Y2lzY29zcGFyazovL2VtL1JPT00vMzUzN2Q2ZTAtMmY5My00N2M0LWIwODMtZDYxNTg3MWZiMzFj"
+        "personId": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS9hODYwYmFkZC0wNGZkLTQwYWEtYWFjNS05NmYyYWRhZDE3NTA"
+        "isModerator": "false"
+    },
+    ...
+}
+```
+
+  A sample consolidated response to such a request will have the status for the original request resposne and a body which might look as follows:
+  ```
+{
+    "testFrameworkResponse": {
+        "id": "Y2lzY29zcGFyazovL2VtL01FTUJFUlNISVAvMDMzMjllODctMzA4Ni00OThiLTg4ZGMtMzM5ZTVhODdlZGEy",
+        "roomId": "Y2lzY29zcGFyazovL2VtL1JPT00vMzUzN2Q2ZTAtMmY5My00N2M0LWIwODMtZDYxNTg3MWZiMzFj",
+        "personId": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS9hODYwYmFkZC0wNGZkLTQwYWEtYWFjNS05NmYyYWRhZDE3NTA",
+        "personEmail": "bot@sparkbot.io",
+        "personDisplayName": "Bot",
+        "personOrgId": "Y2lzY29zcGFyazovL3VzL09SR0FOSVpBVElPTi8xZWI2NWZkZi05NjQzLTQxN2YtOTk3NC1hZDcyY2FlMGUxMGY",
+        "isModerator": false,
+        "isMonitor": false,
+        "created": "2018-03-15T03:12:59.220Z"
+    },
+    "botResponses": [
+        {
+            "method": "POST",
+            "route": "/messages",
+            "body": {
+                "markdown": "Hi! Sorry, I only work in one on one rooms at the moment.  Goodbye.",
+                "roomId": "Y2lzY29zcGFyazovL2VtL1JPT00vMzUzN2Q2ZTAtMmY5My00N2M0LWIwODMtZDYxNTg3MWZiMzFj"
+            }
+        },
+        {
+            "method": "DELETE",
+            "route": "/memberships/Y2lzY29zcGFyazovL2VtL01FTUJFUlNISVAvMDMzMjllODctMzA4Ni00OThiLTg4ZGMtMzM5ZTVhODdlZGEy",
+            "body": {}
+        }
+    ]
+}
+```
+The developer can then use tools like Postman to build a collection of test request and write tests to validate the expected response.
+
+An added benefit of the Bot Test reqression framework is that it can be run on a laptop that is completely offline.   Its great for working on your bot while on an airplane!   In general your bot code itself needs to change only one thing:namely it needs to direct its Cisco Spark API calls to the emulator.   The way this is done varies depending on the framework you are using.
+
+[ToDo] provide example
+
+
+
+## Testing
 
 - The emulator comes with a Postman collection companion to quickly run requests againt the Emulator, and easilly switch back and forth between the emulator and the Cisco Spark API. To install the postman collection:
 

--- a/bot-test/bot-interceptor.js
+++ b/bot-test/bot-interceptor.js
@@ -1,0 +1,33 @@
+//
+// Copyright (c) 2017 Cisco Systems
+// Licensed under the MIT License 
+//
+
+// Middleware to correlate bot responses to bot-test input
+
+const debug = require("debug")("emulator:botInterceptor");
+const sendError = require('../utils').sendError;
+const sendSuccess = require('../utils').sendSuccess;
+var interceptor = require('express-interceptor');
+
+let botInterceptor = interceptor(function(req, res){
+  return {
+    // Only JSON responses will be intercepted 
+    isInterceptable: function(){
+      return /application\/json/.test(res.get('Content-Type'));
+    },
+    // See if this is a response that we've been waiting for
+    intercept: function(body, send) {
+      console.log(body);
+      const db = req.app.locals.datastore;
+      if (db.responses.isTrackedResponse(res, JSON.parse(body))) {
+        console.log('Holding the response while waiting for bot input...');
+      } else {
+        send(body);
+      }
+    }
+  };
+})
+
+
+module.exports = botInterceptor;

--- a/bot-test/bot-interceptor.js
+++ b/bot-test/bot-interceptor.js
@@ -5,7 +5,7 @@
 
 // Middleware to correlate bot responses to bot-test input
 
-const debug = require("debug")("emulator:botInterceptor");
+const debug = require("debug")("emulator:botTest");
 const sendError = require('../utils').sendError;
 const sendSuccess = require('../utils').sendSuccess;
 var interceptor = require('express-interceptor');
@@ -18,10 +18,9 @@ let botInterceptor = interceptor(function(req, res){
     },
     // See if this is a response that we've been waiting for
     intercept: function(body, send) {
-      console.log(body);
       const db = req.app.locals.datastore;
       if (db.responses.isTrackedResponse(res, JSON.parse(body))) {
-        console.log('Holding the response while waiting for bot input...');
+        debug('Holding the response while waiting for bot input...');
       } else {
         send(body);
       }

--- a/bot-test/bot-test.js
+++ b/bot-test/bot-test.js
@@ -31,15 +31,16 @@ botTest.middleware = function (req, res, next) {
     // Check if this is a test request that should generate bot requests 
     const botTestHeader = req.get("X-Bot-Responses");
     if (botTestHeader) {
-        console.log('Found X-Bot-Test header: ' + botTestHeader);
+        debug('Found X-Bot-Test header: %s\n', botTestHeader);
         const db = req.app.locals.datastore;
         db.responses.initResponseObj(req, res, testIdCounter++);
     } else {
+        debug('\n');
         if(res.locals.person.emails[0] == botUnderTestEmail) {
             //See if this is a bot request in response to a test input
             const db = req.app.locals.datastore;
             if (db.responses.isTrackedBotResponse(req)) {
-                console.log('Updated response to test framework with bot request');
+                debug('Updated response to test framework with bot request');
             }  
         }
     }

--- a/bot-test/bot-test.js
+++ b/bot-test/bot-test.js
@@ -1,0 +1,53 @@
+//
+// Copyright (c) 2017 Cisco Systems
+// Licensed under the MIT License 
+//
+
+// Middleware to look for X-Bot-Test
+
+const debug = require("debug")("emulator:botTest");
+const sendError = require('../utils').sendError;
+const sendSuccess = require('../utils').sendSuccess;
+
+let botTest = {};
+let testIdCounter = 1;
+
+botTest.middleware = function (req, res, next) {
+
+    // Public resources
+    if ((req.path == "/") || (req.path == "/tokens")) {
+        next();
+    }
+
+    debug('New Request from: '+ res.locals.person.emails[0]);
+    debug(req.method + ': ' + req.url);
+    if (req.method == 'GET') {
+        debug(req.params);
+    } else {
+        debug(req.body);
+    }
+
+    let botUnderTestEmail = req.app.locals.botUnderTestEmail
+    // Check if this is a test request that should generate bot requests 
+    const botTestHeader = req.get("X-Bot-Responses");
+    if (botTestHeader) {
+        console.log('Found X-Bot-Test header: ' + botTestHeader);
+        const db = req.app.locals.datastore;
+        db.responses.initResponseObj(req, res, testIdCounter++);
+    } else {
+        if(res.locals.person.emails[0] == botUnderTestEmail) {
+            //See if this is a bot request in response to a test input
+            const db = req.app.locals.datastore;
+            if (db.responses.isTrackedBotResponse(req)) {
+                console.log('Updated response to test framework with bot request');
+            }  
+        }
+    }
+    
+    // Check if this is a request from the bot under test
+
+    next();
+}
+
+
+module.exports = botTest;

--- a/bot-test/bot-test.js
+++ b/bot-test/bot-test.js
@@ -12,6 +12,13 @@ const sendSuccess = require('../utils').sendSuccess;
 let botTest = {};
 let testIdCounter = 1;
 
+// Load pre-registered tokens so we can get bot info
+var tokens = require('../tokens.json');
+if (!tokens) {
+    tokens = {};
+}
+
+
 botTest.middleware = function (req, res, next) {
 
     // Public resources
@@ -28,6 +35,17 @@ botTest.middleware = function (req, res, next) {
     }
 
     let botUnderTestEmail = req.app.locals.botUnderTestEmail
+    // The first time we see a request from the bot save its token
+    // so we can look up info about it later
+    if ((!req.app.locals.botActor) && (res.locals.person.emails[0] == botUnderTestEmail)) {
+        const auth = req.get("Authorization");
+        // Extract token -- no error checking since we already passed auth
+        const splitted = auth.match(/^Bearer\s([0-9a-zA-Z]*)$/);
+        // Retreive Person from token
+        const token = splitted[1];
+        req.app.locals.botActor = tokens[token];
+    }
+
     // Check if this is a test request that should generate bot requests 
     const botTestHeader = req.get("X-Bot-Responses");
     if (botTestHeader) {

--- a/controller.js
+++ b/controller.js
@@ -105,7 +105,7 @@ function onMessagesCreated(datastore, actor, message) {
                 method: 'POST',
                 url: notification.targetUrl,
                 headers: {
-                    "Content-type": "application/json; charset=UTF-8",
+                    "Content-type": "application/json;charset=UTF-8",
                     "X-Scheduled-For": notification.created,
                     "User-Agent": "Emulator"
                 },
@@ -194,7 +194,7 @@ function onMembershipsCreated(datastore, actor, membership) {
             method: 'POST',
             url: notification.targetUrl,
             headers: {
-                "Content-type": "application/json; charset=UTF-8",
+                "Content-type": "application/json;charset=UTF-8",
                 "X-Scheduled-For": notification.created,
                 "User-Agent": "Emulator"
             },
@@ -281,7 +281,7 @@ function onMembershipsDeleted(datastore, actor, membership) {
             method: 'POST',
             url: notification.targetUrl,
             headers: {
-                "Content-type": "application/json; charset=UTF-8",
+                "Content-type": "application/json;charset=UTF-8",
                 "X-Scheduled-For": notification.created,
                 "User-Agent": "Emulator"
             },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   "dependencies": {
     "base-64": "^0.1.0",
     "body-parser": "^1.17.2",
+    "dotenv": "^5.0.1",
     "express": "^4.15.3",
+    "express-interceptor": "^1.2.0",
     "request": "^2.81.0",
     "uuid": "^3.1.0"
   },

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "newman run test-cases/CiscoSparkMarkdownTests.postman_collection.json -e test-cases/spark_emulator_tests.postman_environment.json"
   },
   "dependencies": {
     "base-64": "^0.1.0",
     "body-parser": "^1.17.2",
+    "cheerio": "^1.0.0-rc.2",
     "dotenv": "^5.0.1",
     "express": "^4.15.3",
     "express-interceptor": "^1.2.0",

--- a/resources/memberships.js
+++ b/resources/memberships.js
@@ -10,10 +10,6 @@ const express = require("express");
 // default routing properties to mimic Cisco     Spark
 const router = express.Router({ "caseSensitive": true, "strict": false });
 
-// for parsing application/json
-const bodyParser = require("body-parser");
-router.use(bodyParser.json());
-
 // Extra imports 
 const sendError = require('../utils').sendError;
 const sendSuccess = require('../utils').sendSuccess;
@@ -202,6 +198,13 @@ router.get("/:id", function (req, res) {
         return sendSuccess(res, 200, membership);
     });
 });
+
+// Update a membership
+router.put("/:id", function (req, res) {
+    debug(`Update membership not implemented yet`);
+    return sendError(res, 501, "[EMULATOR] Update membership not implemented yet");
+});
+
 
 
 // Delete a membership

--- a/resources/messages.js
+++ b/resources/messages.js
@@ -202,8 +202,10 @@ router.get("/:id", function (req, res) {
                     debug("message ${messageId} not found.")
                     // Note that this is the message returned by Cisco Spark, time of this writing
                     return sendError(res, 404, "Unable to delete message.");
-                case "ROOM_NOT_FOUND":
                 case "USER_NOT_IN_ROOM":
+                    debug("User is not a member of the room associated with provided message ID.")
+                    return sendError(res, 404, "Unable to get message.");
+                case "ROOM_NOT_FOUND":
                     debug("Could not find a room with provided ID.")
                     return sendError(res, 404, "Could not find a room with provided ID.");
                 default:

--- a/sample-bot-test/bot.js
+++ b/sample-bot-test/bot.js
@@ -1,0 +1,76 @@
+//
+// Copyright (c) 2016 Cisco Systems
+// Licensed under the MIT License 
+//
+
+/* 
+ * a Cisco Spark webhook based on pure Express.js.
+ * 
+ * goal here is to illustrate how to create a bot without any library
+ *
+ */
+
+var express = require("express");
+var app = express();
+
+var bodyParser = require("body-parser");
+app.use(bodyParser.urlencoded({extended: true}));
+app.use(bodyParser.json());
+
+var debug = require("debug")("samples");
+var Utils = require("../sparkbot/utils");
+
+
+var started = Date.now();
+app.route("/")
+    // healthcheck
+    .get(function (req, res) {
+        res.json({
+            message: "Congrats, your Cisco Spark bot is up and running",
+            since: new Date(started).toISOString(),
+            code: "express-all-in-one.js",
+            tip: "Register your bot as a WebHook to start receiving events: https://developer.ciscospark.com/endpoint-webhooks-post.html"
+        });
+    })
+
+    // webhook endpoint
+    .post(function (req, res) {
+        
+        // analyse incoming payload, should conform to Spark webhook trigger specifications
+        debug("DEBUG: webhook invoked");
+        if (!req.body || !Utils.checkWebhookEvent(req.body)) {
+            console.log("WARNING: Unexpected payload POSTed, aborting...");
+            res.status(400).json({message: "Bad payload for Webhook",
+                                    details: "either the bot is misconfigured or Cisco Spark is running a new API version"});
+            return;
+        }
+
+        // event is ready to be processed, let's send a response to Spark without waiting any longer
+        res.status(200).json({message: "message is being processed by webhook"});
+
+        // process incoming resource/event, see https://developer.ciscospark.com/webhooks-explained.html
+        processWebhookEvent(req.body);
+    });
+
+
+// Starts the Bot service
+//
+// [WORKAROUND] in some container situation (ie, Cisco Shipped), we need to use an OVERRIDE_PORT to force our bot to start and listen to the port defined in the Dockerfile (ie, EXPOSE), 
+// and not the PORT dynamically assigned by the host or scheduler.
+var port = process.env.OVERRIDE_PORT || process.env.PORT || 8080;
+app.listen(port, function () { 
+    console.log("Cisco Spark Bot started at http://localhost:" + port + "/");
+    console.log("   GET  / for health checks");
+    console.log("   POST / to procress new Webhook events");
+});
+
+
+// Invoked when the Spark webhook is triggered
+function processWebhookEvent(trigger) {
+
+    //
+    // YOUR CODE HERE
+    //
+    console.log("EVENT: " + trigger.resource + "/" + trigger.event + ", with data id: " + trigger.data.id + ", triggered by person id:" + trigger.actorId);
+      
+}

--- a/server.js
+++ b/server.js
@@ -33,6 +33,7 @@ app.set("etag", false); // to mimic Cisco Spark headers
 // Middleware to mimic Cisco Spark HTTP headers
 app.use(function (req, res, next) {
     res.setHeader("Cache-Control", "no-cache"); // to mimic Cisco Spark headers
+    res.setHeader("Content-Type", "application/json;charset=UTF-8"); // to mimic Cisco Spark headers
 
     // New Trackingid
     res.locals.trackingId = "EM_" + uuid();

--- a/storage/markdown-manipulator.js
+++ b/storage/markdown-manipulator.js
@@ -1,0 +1,157 @@
+//
+// Copyright (c) 2017 Cisco Systems
+// Licensed under the MIT License 
+//
+
+// Lib for converting markdown to HTML
+var showdown  = require('showdown');
+// Custom extension for adding nofollow to anchor links
+var anchorAttributes = {
+    type: 'output',
+    regex: /(<a.+<\/a>)/g,
+    replace: (match, $1) => {
+      return $1.replace('">', '" rel="nofollow">');
+    }
+  };
+showdown.extension('anchorAttributes', anchorAttributes);  
+showdown.setOption('noHeaderId', 'true');
+showdown.setOption('omitExtraWLInCodeBlocks', 'true');
+
+
+function MarkdownManipulator() {
+
+    this.markdown2html = new showdown.Converter({ extensions: ['anchorAttributes'] });
+    this.markdown2html.setOption('noHeaderId', 'true');
+    this.markdown2html.setOption('omitExtraWLInCodeBlocks', 'true');
+    
+    this.INPUT_PERSONID_PATTERN_WITHOUT_DISPLAYNAME = "<@personId:%s>";
+    this.INPUT_PERSONID_PATTERN_WITH_DISPLAYNAME = "<@personId:%s|%s>";
+    this.INPUT_PERSONEMAIL_PATTERN_WITHOUT_DISPLAYNAME = "<@personEmail:%s>";
+    this.INPUT_PERSONEMAIL_PATTERN_WITH_DISPLAYNAME = "<@personEmail:%s|%s>";
+
+    this.HREF_PATTERN_STRING = "<a href=\"%s\">";
+    this.OUTPUT_PATTERN = "<spark-mention data-object-type=\"person\" data-object-id=\"%s\">%s</spark-mention>";
+    this.GROUP_MENTION_OUTPUT_PATTERN = "<spark-mention data-object-type=\"groupMention\" data-object-id=\"%s\">%s</spark-mention>";
+    this.OUTPUT_MENTION_PATTERN = "<spark-mention data-object-type=\"person\" data-object-id=\"%s\">";
+/*
+    public static Pattern MENTIONS_PATTERN = Pattern.compile("<spark-mention data-object-type=\"person\" data-object-id=\\\"(.*?)\\\">");
+    public static Pattern GROUP_MENTIONS_PATTERN = Pattern.compile("<spark-mention data-object-type=\"groupMention\" data-object-id=\\\"(.*?)\\\">");
+    public static Pattern PERSON_ID_PATTERN = Pattern.compile("<@personId:(.*?)>");
+    public static Pattern PERSON_EMAIL_PATTERN = Pattern.compile("<@personEmail:(.*?)>");
+    public static Pattern HREF_PATTERN = Pattern.compile("<a href=\"(.*?)\">");
+    public static Pattern GROUP_MENTIONS_ALL_PATTERN = Pattern.compile("<@all>", Pattern.CASE_INSENSITIVE);
+    public static Pattern GROUP_MENTIONS_HERE_PATTERN = Pattern.compile("<@here>", Pattern.CASE_INSENSITIVE);
+*/
+}
+
+MarkdownManipulator.prototype.buildMentionedPeopleArray = function (markdown) {
+    let mentionInfo = {
+        mentionedPeople: [],
+        newMarkdown: markdown,
+        newText: markdown
+    };
+    //TODO -- check for mentioned people by personEmail
+    // Extract out the mentioned personId and Name
+    re = new RegExp("<@personId:(.*?)>", 'g')
+    //TODO - fix this regex so it works with multiple mentions.
+    // After many hours trying and reading stackoverflow I just can't
+    // figure out how to write a "non greedy" regex that doesn't take just
+    // the last mention.  For example if the payload is this:
+    // <@personId:Y2lz...A|JP>, <@personId:Y2l...g|The Bot I'm Testing>, This is a mention for JP and the bot"
+    // The matcher will eat the first person and return only the personId and name of the last user mentioned
+    while((match = re.exec(markdown)) != null) {
+        let personId = match[1].trim();
+        let isEmptyDisplayName = false;
+        if (personId.endsWith("|")) {
+            personId = personId.substring(0, personId.length() - 1);
+            isEmptyDisplayName = true;
+        }
+        if (personId.includes("|")) {
+            let mentionId = personId.substring(0, personId.indexOf("|"));
+            let mentionName = personId.substring(personId.indexOf("|") + 1);
+            mentionInfo.newMarkdown = this.addDisplayNameForMentions(mentionInfo.newMarkdown, 
+                null, mentionId, mentionName, true, isEmptyDisplayName);
+            mentionInfo.mentionedPeople.push(personId.substring(0, personId.indexOf("|")));
+            mentionInfo.newText = mentionInfo.newText.replace(match[0], mentionName);
+        } else {
+            //TODO Handle cases when the API call does not specify a name
+            inputMessage = addDisplayNameForMentions(inputMessage, null, personId, 
+                getDisplayName(personId), false, isEmptyDisplayName);
+            mentionInfo.mentionedPeople.push(personId);
+        }
+    }
+    return mentionInfo;
+}
+
+MarkdownManipulator.prototype.addDisplayNameForMentions = function (inputMessage, personEmail, personId, displayName, displayNameProvided, isEmptyDisplayName) {
+    // TODO Index into tokens.json to see if the ID is asscoiated with a person or a bot (or even exists!)
+    // For now we'll just assume its a person
+    //String decodedPersonId = ResourceUtility.getStringFromBase64Id(personId, ResourceUtility.ResourceType.PEOPLE);
+    //String outputMessage = String.format(HydraMarkdownProperties.OUTPUT_PATTERN, decodedPersonId, displayName);
+
+    let outputMessage = this.OUTPUT_PATTERN.printf(personId, displayName);
+    let inputMention = ''
+    if (personEmail == null) {
+        if (displayNameProvided) {
+            inputMention = this.INPUT_PERSONID_PATTERN_WITH_DISPLAYNAME.printf(personId, displayName);
+        } else {
+            if (isEmptyDisaplayName) {
+                inputMention = this.INPUT_PERSONID_PATTERN_WITH_DISPLAYNAME.printf(personId, '');
+            } else {
+                inputMention = this.INPUT_PERSONID_PATTERN_WITHOUT_DISPLAYNAME.printf(personId);
+            }
+        }
+        return inputMessage.replace(inputMention, outputMessage);
+    } else {
+        if (displayNameProvided) {
+            inputMention = this.INPUT_PERSONEMAIL_PATTERN_WITH_DISPLAYNAME.printf(personEmail, displayName);
+        } else {
+            if (isEmptyDisaplayName) {
+                inputMention = this.INPUT_PERSONEMAIL_PATTERN_WITH_DISPLAYNAME.printf(personEmail, '');
+            } else {
+                inputMention = this.INPUT_PERSONEMAIL_PATTERN_WITHOUT_DISPLAYNAME.printf(personEmail);
+            }
+        }
+        return inputMessage.replace(inputMention, outputMessage);
+    }
+}
+
+MarkdownManipulator.prototype.convertMarkdownToHtml = function (markdown) {
+    return this.markdown2html.makeHtml(markdown);
+}
+
+
+// Support java like sprintf capabilities
+// Works for strings only
+String.prototype.printf = function (obj) {
+    var useArguments = false;
+    var _arguments = arguments;
+    var i = -1;
+    if (typeof _arguments[0] == "string") {
+      useArguments = true;
+    }
+    if (obj instanceof Array || useArguments) {
+      return this.replace(/\%s/g,
+      function (a, b) {
+        i++;
+        if (useArguments) {
+          if (typeof _arguments[i] == 'string') {
+            return _arguments[i];
+          }
+          else {
+            throw new Error("Arguments element is an invalid type");
+          }
+        }
+        return obj[i];
+      });
+    }
+    else {
+      return this.replace(/{([^{}]*)}/g,
+      function (a, b) {
+        var r = obj[b];
+        return typeof r === 'string' || typeof r === 'number' ? r : a;
+      });
+    }
+  };
+  
+  module.exports = MarkdownManipulator;

--- a/storage/memory.js
+++ b/storage/memory.js
@@ -22,5 +22,7 @@ const MessageStorage = require("./messages");
 datastore.messages = new MessageStorage(datastore);
 const WebhookStorage = require("./webhooks");
 datastore.webhooks = new WebhookStorage(datastore);
+const ResponseStorage = require("./response-builder")
+datastore.responses = new ResponseStorage(datastore);
 
 module.exports = datastore;

--- a/storage/messages.js
+++ b/storage/messages.js
@@ -42,6 +42,11 @@ MessageStorage.prototype.createInRoom = function (actor, room, text, markdown, f
         // .use(require('markdown-it-sanitizer'));
         // md.render('<b>test<p></b>'); // => '<p><b>test</b></p>' 
         message.html = markdown;
+        // Check if we need to build a mentionedPeople array
+        let mentionedPeople = buildMentionedPeopleArray(markdown);
+        if (mentionedPeople.length) {
+            message.mentionedPeople = mentionedPeople;
+        }
     }
 
     // Store message
@@ -114,6 +119,19 @@ MessageStorage.prototype.find = function (actor, messageId, cb) {
             cb(null, message);
         }
     });
+}
+
+function buildMentionedPeopleArray(markdown) {
+    let mentionedPeople = [];
+    //TODO -- check for mentioned people by personEmail
+    re = /.*\<@personId\:(.*)\|.*/
+    let personId = markdown.replace(re, '$1');
+    if (personId) {
+        mentionedPeople.push(personId)
+    }
+    //TODO -- This just gets the last mentioned person if multiples are mentioned
+    // Figure out how to get all of them!
+    return mentionedPeople
 }
 
 

--- a/storage/response-builder.js
+++ b/storage/response-builder.js
@@ -1,0 +1,183 @@
+//
+// Copyright (c) 2017 Cisco Systems
+// Licensed under the MIT License 
+//
+
+/*
+ * Helper module to manipulate response from the spark emulator
+ * The emulator inspects all requests.  Requests from the test framework
+ * that emulate user activity may include an X-Bot-Response header.
+ * When this headers has a value greater than zero the emulator framework
+ * will intercept responses and hold the response to the test request
+ * until it also recieves the coorect number of responses to bot requests
+ * as well
+ * 
+ */
+
+const assert = require("assert");
+const uuid = require('uuid/v4');
+const base64 = require('base-64');
+const debug = require("debug")("emulator:storage:response-builder");
+// Extra imports 
+const sendError = require('../utils').sendError;
+const sendSuccess = require('../utils').sendSuccess;
+
+
+function ResponseStorage(datastore) {
+    this.datastore = datastore;
+    this.data = [];
+}
+
+ResponseStorage.prototype.initResponseObj = function (req, res, testId) {
+
+    assert.ok(req);
+    let expectedBotResponses = req.get('X-Bot-Responses');
+
+    // Set the testId in the request header so we can catch the initial
+    // response to the request from the test framework
+    res.setHeader('X-Bot-Test-Id', testId);
+
+    // Create an object for building the response to the test framework
+    var respObj = {
+        "testId": testId,
+        "response": {},
+        "expectedBotResponses": parseInt(req.get('X-Bot-Responses')),
+        "seenBotResponses": 0,
+        "roomId": '',
+        "membershipId": ''
+    }
+
+    // Store reqObj
+    this.data[testId] = respObj;
+}
+
+ResponseStorage.prototype.removeResponseObj = function (index) {
+
+    this.data.splice(index);
+}
+
+// Check if this is a response to a request with a tracking ID
+// If so save the response object so we can send it after we get
+// the expected bot responses
+ResponseStorage.prototype.isTrackedResponse = function(response, body) {
+    if (!this.data.length) {
+        return false;
+    }
+
+    assert.ok(response);
+    if (response.statusCode != 200) {
+        return false;
+    }
+
+    let testId = response.get('X-Bot-Test-Id');
+    if ((!testId) || (!this.data[testId])) {
+        return false;
+    }
+
+    let respObj = this.data[testId];
+    if (respObj.roomId) {
+    } else {
+        // This is the response to the original spark API request from the 
+        // test framework.  Store it now to send after we get the bot responses
+        respObj.response = response;
+        respObj.body = body;
+        // Add the roomId which we'll use to correlate bot responses
+        respObj.roomId = body.roomId;
+        respObj.membershipId = body.id;
+        return true;
+    }
+    return false;
+}
+
+// Check if this is a bot request in response to a test request 
+// If so save the info about the request in the test framework response
+ResponseStorage.prototype.isTrackedBotResponse = function(req) {
+    if (!this.data.length) {
+        return false;  // No test requests awaiting responses
+    }
+
+    assert.ok(req);
+    if (req.method == 'GET') {
+        return false;  // Not interested in responses to webhooks
+    }
+
+    let id = '';
+    let keyName = '';
+    if (req.method == 'DELETE') {
+        let parts = req.url.split('/')
+        let endpoint = parts[1];
+        if (endpoint === 'memberships') {
+            id = parts[2];
+            keyName = 'membershipId';
+        }
+    } else {
+        id = req.body.roomId;
+        keyName = 'roomId'
+    }
+    // Iterate through all the stored responses until
+    // we find one with this roomID
+    const self = this;
+    let respObjs = [];
+    let index = 0;
+    Object.keys(this.data).forEach(function (key) {
+        let respObj = self.data[key];
+        if (respObj[keyName] == id) {
+            index = key;
+            respObjs.push(respObj);
+        }
+    });
+    console.log('Found %d saved responses that match bot request', respObjs.length);
+    if (!respObjs.length) {
+        return false;
+    } else if (respObjs.length > 1) {
+        // Need a better way to deal with this
+        console.error('Too many saved responses that match this room!  Bailing')
+        return false;
+    } else {
+        // This must be a BotResponse that correlates to an earlier
+        // request from the test framework.  Add it to the response 
+        let respObj = respObjs[0];
+        if (!respObj.seenBotResponses) {
+            respObj.body = buildComplexResponseBody(respObj.body, req);
+        } else {
+            respObj.body = addToComplexResponseBody(respObj.body, req);            
+        }
+        respObj.seenBotResponses += 1;
+        if (respObj.seenBotResponses == respObj.expectedBotResponses) {
+            // We have all the bot responses we are waiting for
+            // Send the new complex response to the test framework
+            sendSuccess(respObj.response, 200, respObj.body);
+            // Remove the response from our db of test responses to process
+            self.removeResponseObj(index);
+        }
+        return true;
+    }
+}    
+
+// Replace the original response body with an object that
+// includes both the response to the original test
+// framework request as well as one or more bot objects
+function buildComplexResponseBody(testBody, req) {
+    return {
+        'testFrameworkResponse': testBody,
+        'botResponses': [{
+            'method': req.method,
+            'route': req.url,
+            'body': req.body
+        }]
+    }
+}
+
+// Add another bot Response to the existing complexResponseBody
+// includes both the response to the original test
+// framework request as well as one or more bot objects
+function addToComplexResponseBody(testBody, req) {
+    testBody.botResponses.push({
+        'method': req.method,
+        'route': req.url,
+        'body': req.body    
+    });
+    return (testBody);
+}
+
+module.exports = ResponseStorage;

--- a/storage/response-builder.js
+++ b/storage/response-builder.js
@@ -88,7 +88,23 @@ ResponseStorage.prototype.isTrackedResponse = function(response, body) {
         respObj.body = body;
         // Add the roomId which we'll use to correlate bot responses
         respObj.roomId = body.roomId;
-        respObj.membershipId = body.id;
+        // If the bot is in this room, store its membershipID
+        if (response.req.app.locals.botActor) {
+            const actor = response.req.app.locals.botActor;
+            if (body.roomId) {
+                const db = response.req.app.locals.datastore;
+                db.memberships.listMembershipsForRoom(actor, body.roomId, function (err, list) {
+                    if ((!err) && (list.length)) {
+                        for (var i=0; i<list.length; i++) {
+                            if (list[i].personId == actor.id) {
+                                respObj.membershipId = list[i].id;
+                                break;
+                            }
+                        }
+                    }
+                });
+            }
+        }
         return true;
     }
     return false;

--- a/test-cases/CiscoSparkMarkdownTests.postman_collection.json
+++ b/test-cases/CiscoSparkMarkdownTests.postman_collection.json
@@ -1,0 +1,1264 @@
+{
+	"info": {
+		"name": "Cisco Spark Markdown Tests",
+		"_postman_id": "72196756-2129-4c42-9dbb-1c51853096c2",
+		"description": "This set of tests posts a series of messages with markdown to Spark and the Spark Emulator and compares the results.\n\nIt requires an enviornment that specifies:\n* API_URL -- THe URL of the live Spark API\n* spark_token -- A valid auth token for calling Spark\n* tester_id -- the person ID of the holder of spark_token\n* tester_display_name -- the display name of the holder of spark_token\n* tester_nickname -- the nickname of the holder of the spark_token\n* tester_email -- the mail of the holder of the spark_token\n* person2_id: -- the person ID of a second person that can be added to the spark room\n* person2_email - the spark email for the second person\n* person2_display_name - the second person's spark display name\n* person2_nickname -- the second person's nickname\n\n* EMULATOR_URL - The URL of the Spark Emulator being tested\n* emulator_token - The token of a user specified in the emulator's token.json file\n* emulator_display_name - The display name associated with that user in token.json\n* emulator_nickname - The nickname associated with that user in token.json\n* emulator_id - The person ID associated with that user in token.json\n* emulator_email - The email associated with that user in token.json\n* emulator_person2_id The person ID of a second user defined in the emulator's token.json file\n* emulator_person2_email: - The email associated with that user in token.json\n* emulator_person2_display_name - The display name associated with that user in token.json\n* emulator_person2_nickname - The nickname associated with that user in token.json\n",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Spark Create a group room (and define global tests)",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "3df40439-b0b0-4ab1-b7a8-47f6e4759ead",
+						"type": "text/javascript",
+						"exec": [
+							"// Save common tests in a global variable",
+							"// Check if the initial test request returned the expected value",
+							"postman.setGlobalVariable(\"commonTests\", (task, status) => {",
+							"  // We expect a 200 OK",
+							"  tests[task + \" returned \" + status] = responseCode.code === status;",
+							"  // The Content-Type must be JSON",
+							"  tests[\"Content-Type header is set\"] = postman.getResponseHeader(\"Content-Type\") === \"application/json;charset=UTF-8\";",
+							"});",
+							"",
+							"// Collect the headers in a response from Spark ",
+							"postman.setGlobalVariable(\"getHeaders\", () => {",
+							"    postman.setEnvironmentVariable(\"_sparkContentTypeHeader\", postman.getResponseHeader(\"Content-Type\"));",
+							"});",
+							"",
+							"// Compare emulator response headers to spark response headers",
+							"postman.setGlobalVariable(\"compareHeaders\", () => {",
+							"  tests[\"Emulator Content-Type header matches spark\"] = postman.getResponseHeader(\"Content-Type\") === postman.getEnvironmentVariable(\"_sparkContentTypeHeader\");",
+							"});",
+							"",
+							"// Collect the message elements returned by spark",
+							"postman.setGlobalVariable(\"getMessageElements\", (body) => {",
+							"    console.log(body.text)",
+							"    postman.setEnvironmentVariable(\"_sparkText\", body.text);",
+							"    postman.setEnvironmentVariable(\"_sparkHtml\", body.html);",
+							"    postman.setEnvironmentVariable(\"_sparkMarkdown\", body.markdown);",
+							"    if (body.mentionedPeople) {",
+							"        postman.setEnvironmentVariable(\"_sparkMentionsCount\", body.mentionedPeople.length);",
+							"    } else {",
+							"        postman.setEnvironmentVariable(\"_sparkMentionsCount\", 0);        ",
+							"    }",
+							"});",
+							"",
+							"",
+							"",
+							"// Compare emulator message elements with spark",
+							"postman.setGlobalVariable(\"compareMessageElements\", (body, sparkIds, emulatorIds) => {",
+							"  let sparkIdRegex = '';",
+							"  let emulatorIdRegex = '';",
+							"  let sparkHtml = postman.getEnvironmentVariable(\"_sparkHtml\");",
+							"  let emulatorHtml = body.html;",
+							"  let sparkMarkdown = postman.getEnvironmentVariable(\"_sparkMarkdown\");",
+							"  let emulatorMarkdown = body.markdown;",
+							"  // Strip user IDs from HTML and Markdown before comparing",
+							"  // Spark and the emulator since they will be different",
+							"  if ((sparkIds) && (sparkIds.length)) {",
+							"      sparkIdRegex = new RegExp(sparkIds.join('|'), 'g');",
+							"      sparkMarkdown = sparkMarkdown.replace(sparkIdRegex, '');",
+							"      sparkHtml = sparkHtml.replace(sparkIdRegex, '');",
+							"  }",
+							"  if ((emulatorIds) && (emulatorIds.length)) {",
+							"      emulatorIdRegex = new RegExp(emulatorIds.join('|'), 'g')",
+							"      emulatorMarkdown = emulatorMarkdown.replace(emulatorIdRegex, '');",
+							"      emulatorHtml = emulatorHtml.replace(emulatorIdRegex, '');",
+							"  }",
+							"  tests[\"Emulator Message text matches spark\"] = body.text.replace(/\\n|\\s/gm, '') === postman.getEnvironmentVariable(\"_sparkText\").replace(/\\n|\\s/gm, '');",
+							"  tests[\"Emulator Message html matches spark\"] = emulatorHtml.replace(/\\n|\\s/gm, '') === sparkHtml.replace(/\\n|\\s/gm, '');",
+							"  tests[\"Emulator Message markdown matches spark\"] = emulatorMarkdown === sparkMarkdown;",
+							"  ",
+							"  if (body.mentionedPeople) {",
+							"      tests[\"Emulator mentionPeople arr length matches spark\"] = body.mentionedPeople.length == postman.getEnvironmentVariable(\"_sparkMentionsCount\");",
+							"    } else {",
+							"      tests[\"Emulator mentionPeople arr length matches spark\"] = 0 === postman.getEnvironmentVariable(\"_sparkMentionsCount\");  ",
+							"    }",
+							"});",
+							"",
+							"",
+							"// Run the common tests for the create room request",
+							"eval(globals.commonTests)(\"Create room\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders)();",
+							"",
+							"// Assuming all went well get the room id  ",
+							"var jsonData = JSON.parse(responseBody);",
+							"if (jsonData.id === undefined) {",
+							"    tests[\"Create a room: cannot retreive room identifier\"] = false",
+							"}",
+							"else {",
+							"    var roomID = jsonData.id;",
+							"    postman.setEnvironmentVariable(\"_room\", roomID);",
+							"    tests[\"Create a room: created with id:\" + roomID] = true",
+							"}",
+							"",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "",
+						"value": "",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"title\": \"Markdown-Tester-Room\"\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/rooms",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"rooms"
+					]
+				},
+				"description": "Creates a room. The authenticated user is automatically added as a member of the room. \n\nOn the test tab we define some global tests methods that will be used in subseqent test cases.\n\nIn addition we capture the roomId of the created room and store it in the _roomId environment variable for us in subseqent requests."
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator Create a group room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "6f43f006-fde1-4385-bec3-de9d49363203",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Create room\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"",
+							"// Assuming all went well get the room id  ",
+							"var jsonData = JSON.parse(responseBody);",
+							"if (jsonData.id === undefined) {",
+							"    tests[\"Create a room: cannot retreive room identifier\"] = false",
+							"}",
+							"else {",
+							"    var roomID = jsonData.id;",
+							"    postman.setEnvironmentVariable(\"_emulatorRoom\", roomID);",
+							"    tests[\"Create a room: created with id:\" + roomID] = true",
+							"}",
+							"",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					},
+					{
+						"key": "",
+						"value": "",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"title\": \"Markdown-Tester-Room\"\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/rooms",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"rooms"
+					]
+				},
+				"description": "Creates a room. The authenticated user is automatically added as a member of the room. \n\nOn the test tab we define some global tests methods that will be used in subseqent test cases.\n\nIn addition we capture the roomId of the created room and store it in the _roomId environment variable for us in subseqent requests."
+			},
+			"response": []
+		},
+		{
+			"name": "Create a markdown message",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "cefa32c1-afed-49be-ab29-2defb85be835",
+						"type": "text/javascript",
+						"exec": [
+							"",
+							"// Run the common tests for the create room request",
+							"eval(globals.commonTests)(\"Create markdown message in Spark\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getMessageElements)(JSON.parse(responseBody));",
+							"",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_room}}\",\r\n  \"markdown\" : \"# Message Formatting!\\nSpark clients now render rich text; enabling bots and integrations to communicate business data in a way that's fun to read and easy on the eyes!\\n\\n## Styling Text\\nMessages are styled using [Markdown](https://daringfireball.net/projects/markdown/syntax) syntax allowing text to be emphasized in **bold**, *italics* on `in-line code`.\\n\\n### Fenced Code Blocks\\nSpark can now also render fenced code blocks using triple backticks (aka GitHub Flavored Markdown)\\n\\n```\\nsource 'https://github.com/CocoaPods/Specs.git'\\nplatform :ios, '8.0'\\nuse_frameworks!\\n\\npost_install do |installer|\\n  installer.pods_project.targets.each do |target|\\n    target.build_configurations.each do |config|\\n      config.build_settings['ENABLE_BITCODE'] = 'NO'\\n    end\\n  end\\nend\\n\\ntarget 'SparkBnB' do\\n  pod 'SparkSDK', :path => '../'\\n  pod 'Toast-Swift', '~> 1.1.0'\\nend\\n```\\n\\n### Lists\\n\\nLists are a great way to organize information or present options to your audience.\\n\\nOrderd Lists\\n1. List Item\\n2. List Item\\n3. List Item\\n\\nUnordered Lists\\n* List Item\\n* List Item\\n* List Item\\n\\n### Block Quotes\\n\\n> Quoting is a super powerful way for bots to respond to a message that happened a while back in the conversation.\",\r\n  \"text\": \"This text would be displayed by Spark clients that would not support Markdown.\"\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator Create a markdown message",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "5795ae74-4c17-4976-b1a7-c0740644f51e",
+						"type": "text/javascript",
+						"exec": [
+							"",
+							"// Run the common tests for the create room request",
+							"eval(globals.commonTests)(\"Create markdown message in Emulator\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareMessageElements)(JSON.parse(responseBody));",
+							"",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_emulatorRoom}}\",\r\n  \"markdown\" : \"# Message Formatting!\\nSpark clients now render rich text; enabling bots and integrations to communicate business data in a way that's fun to read and easy on the eyes!\\n\\n## Styling Text\\nMessages are styled using [Markdown](https://daringfireball.net/projects/markdown/syntax) syntax allowing text to be emphasized in **bold**, *italics* on `in-line code`.\\n\\n### Fenced Code Blocks\\nSpark can now also render fenced code blocks using triple backticks (aka GitHub Flavored Markdown)\\n\\n```\\nsource 'https://github.com/CocoaPods/Specs.git'\\nplatform :ios, '8.0'\\nuse_frameworks!\\n\\npost_install do |installer|\\n  installer.pods_project.targets.each do |target|\\n    target.build_configurations.each do |config|\\n      config.build_settings['ENABLE_BITCODE'] = 'NO'\\n    end\\n  end\\nend\\n\\ntarget 'SparkBnB' do\\n  pod 'SparkSDK', :path => '../'\\n  pod 'Toast-Swift', '~> 1.1.0'\\nend\\n```\\n\\n### Lists\\n\\nLists are a great way to organize information or present options to your audience.\\n\\nOrderd Lists\\n1. List Item\\n2. List Item\\n3. List Item\\n\\nUnordered Lists\\n* List Item\\n* List Item\\n* List Item\\n\\n### Block Quotes\\n\\n> Quoting is a super powerful way for bots to respond to a message that happened a while back in the conversation.\",\r\n  \"text\": \"This text would be displayed by Spark clients that would not support Markdown.\"\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/messages",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Create a markdown message without alternate text",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d8ba774b-48df-4668-9908-3a60cabec964",
+						"type": "text/javascript",
+						"exec": [
+							"// Run the common tests for the create room request",
+							"eval(globals.commonTests)(\"Markdown message with no alternate text in Spark\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getMessageElements)(JSON.parse(responseBody));",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_room}}\",\r\n  \"markdown\" : \"# Message Formatting!\\nSpark clients now render rich text; enabling bots and integrations to communicate business data in a way that's fun to read and easy on the eyes!\\n\\n## Styling Text\\nMessages are styled using [Markdown](https://daringfireball.net/projects/markdown/syntax) syntax allowing text to be emphasized in **bold**, *italics* on `in-line code`.\\n\\n### Fenced Code Blocks\\nSpark can now also render fenced code blocks using triple backticks (aka GitHub Flavored Markdown)\\n\\n```\\nsource 'https://github.com/CocoaPods/Specs.git'\\nplatform :ios, '8.0'\\nuse_frameworks!\\n\\npost_install do |installer|\\n  installer.pods_project.targets.each do |target|\\n    target.build_configurations.each do |config|\\n      config.build_settings['ENABLE_BITCODE'] = 'NO'\\n    end\\n  end\\nend\\n\\ntarget 'SparkBnB' do\\n  pod 'SparkSDK', :path => '../'\\n  pod 'Toast-Swift', '~> 1.1.0'\\nend\\n```\\n\\n### Lists\\n\\nLists are a great way to organize information or present options to your audience.\\n\\nOrderd Lists\\n1. List Item\\n2. List Item\\n3. List Item\\n\\nUnordered Lists\\n* List Item\\n* List Item\\n* List Item\\n\\n### Block Quotes\\n\\n> Quoting is a super powerful way for bots to respond to a message that happened a while back in the conversation.\"\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator create a markdown message without alternate text",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "b3366dce-e805-4e04-9356-de40b80a1bc2",
+						"type": "text/javascript",
+						"exec": [
+							"",
+							"// Run the common tests for the create room request",
+							"eval(globals.commonTests)(\"Markdown message no alternate text in Emulator\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareMessageElements)(JSON.parse(responseBody));",
+							"",
+							"    ",
+							"",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_emulatorRoom}}\",\r\n  \"markdown\" : \"# Message Formatting!\\nSpark clients now render rich text; enabling bots and integrations to communicate business data in a way that's fun to read and easy on the eyes!\\n\\n## Styling Text\\nMessages are styled using [Markdown](https://daringfireball.net/projects/markdown/syntax) syntax allowing text to be emphasized in **bold**, *italics* on `in-line code`.\\n\\n### Fenced Code Blocks\\nSpark can now also render fenced code blocks using triple backticks (aka GitHub Flavored Markdown)\\n\\n```\\nsource 'https://github.com/CocoaPods/Specs.git'\\nplatform :ios, '8.0'\\nuse_frameworks!\\n\\npost_install do |installer|\\n  installer.pods_project.targets.each do |target|\\n    target.build_configurations.each do |config|\\n      config.build_settings['ENABLE_BITCODE'] = 'NO'\\n    end\\n  end\\nend\\n\\ntarget 'SparkBnB' do\\n  pod 'SparkSDK', :path => '../'\\n  pod 'Toast-Swift', '~> 1.1.0'\\nend\\n```\\n\\n### Lists\\n\\nLists are a great way to organize information or present options to your audience.\\n\\nOrderd Lists\\n1. List Item\\n2. List Item\\n3. List Item\\n\\nUnordered Lists\\n* List Item\\n* List Item\\n* List Item\\n\\n### Block Quotes\\n\\n> Quoting is a super powerful way for bots to respond to a message that happened a while back in the conversation.\"\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/messages",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Spark @mention by id someone not in room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "e125d0a9-9737-4366-8dae-c65d937d7dc2",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message by id not in room in Spark\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getMessageElements)(JSON.parse(responseBody));",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_room}}\",\r\n  \"markdown\" : \"<@personId:{{person2_id}}|{{emulator_person2_nickname}}> This is a mention for {{emulator_person2_display_name}}\"\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator @mention by id someone not in room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "c4dd0a5d-7153-4c58-a302-ff304379abcf",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message by id not in room in Emulator\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"",
+							"// Collect the headers from the real Spark call",
+							"let sparkIds = [postman.getEnvironmentVariable('person2_id')];",
+							"let emulatorIds = [postman.getEnvironmentVariable('emulator_person2_id')];",
+							"eval(globals.compareMessageElements)(JSON.parse(responseBody), sparkIds, emulatorIds);",
+							"",
+							"    ",
+							"",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_emulatorRoom}}\",\r\n  \"markdown\" : \"<@personId:{{emulator_person2_id}}|{{emulator_person2_nickname}}> This is a mention for {{emulator_person2_display_name}}\"\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/messages",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Spark @mention by id with invalid ID",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "b1ec4127-2f0a-4c74-b060-050219d12b86",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message by invalid ID in Spark\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getMessageElements)(JSON.parse(responseBody));",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_room}}\",\r\n  \"markdown\" : \"<@personId:12345|{{emulator_person2_nickname}}> This is a mention for {{emulator_person2_display_name}}\"\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator @mention by id with invalid ID",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "a9663fec-bf93-4979-b086-acf3ab3c420d",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message by invalid ID in Emulator\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"let sparkIds = [\"12345\"];",
+							"let emulatorIds = [\"1234\"];",
+							"eval(globals.compareMessageElements)(JSON.parse(responseBody), sparkIds, emulatorIds);",
+							"",
+							"    ",
+							"",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_emulatorRoom}}\",\r\n  \"markdown\" : \"<@personId:1234|{{emulator_person2_nickname}}> This is a mention for {{emulator_person2_display_name}}\"\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/messages",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Spark @mention by email someone not in room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "07cdd245-2529-48b3-a0bc-068b2f1a26b3",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message by email not in room in Spark\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getMessageElements)(JSON.parse(responseBody));",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_room}}\",\r\n  \"markdown\" : \"<@personEmail:{{person2_email}}|{{emulator_person2_nickname}}> This is a mention for {{emulator_person2_display_name}}\"\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator @mention by email someone not in room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "53fba5a2-0344-410f-b601-e2a8cfffa6b6",
+						"type": "text/javascript",
+						"exec": [
+							"",
+							"// Run the common tests for the create room request",
+							"eval(globals.commonTests)(\"Mention message by email not in room in Emulator\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareMessageElements)(JSON.parse(responseBody));",
+							"",
+							"    ",
+							"",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_emulatorRoom}}\",\r\n  \"markdown\" : \"<@personEmail:{{emulator_person2_email}}|{{emulator_person2_nickname}}> This is a mention for {{emulator_person2_display_name}}\"\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/messages",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Spark Add Person2 to the room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "1fdd112f-19eb-47c0-b49f-c8ec7d4ee675",
+						"type": "text/javascript",
+						"exec": [
+							"// First, run the common tests",
+							"eval(globals.commonTests)(\"Spark: Add Person2 to room\", 200);",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n\t\"roomId\": \"{{_room}}\",\r\n\t\"personId\": \"{{person2_id}}\",\r\n    \"isModerator\": false\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/memberships",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"memberships"
+					]
+				},
+				"description": "Adds the bot to the previously created room.   Note that the bot is added via the personId element in the body.  The cisco spark emulator does not fully support referring to users via email yet.\n\nThe bot's person id should be specified in the bot_id environment variable.\n\nNo bot response is expected to this test."
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator Add Person2 to the room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "67974518-c083-4c58-a7d7-e3cda903093a",
+						"type": "text/javascript",
+						"exec": [
+							"// First, run the common tests",
+							"eval(globals.commonTests)(\"Emulator: Add Person2 to room\", 200);",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n\t\"roomId\": \"{{_emulatorRoom}}\",\r\n\t\"personId\": \"{{emulator_person2_id}}\",\r\n    \"isModerator\": false\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/memberships",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"memberships"
+					]
+				},
+				"description": "Adds the bot to the previously created room.   Note that the bot is added via the personId element in the body.  The cisco spark emulator does not fully support referring to users via email yet.\n\nThe bot's person id should be specified in the bot_id environment variable.\n\nNo bot response is expected to this test."
+			},
+			"response": []
+		},
+		{
+			"name": "Spark markdown message with personId mention and wrong name",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "1f898636-71c0-4784-a64e-56d04d49b21a",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message by id and custom name in Spark\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getMessageElements)(JSON.parse(responseBody));",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_room}}\",\r\n  \"markdown\" : \"<@personId:{{person2_id}}|Made up name> This is a mention for JP, aka Made up Name\"\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator markdown message with personId mention and wrong name",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "dc2af488-e2e7-456e-a83c-d0b2fe7a5a7f",
+						"type": "text/javascript",
+						"exec": [
+							"// Run the common tests for the create room request",
+							"eval(globals.commonTests)(\"Mention message by id and custom name in Emulator\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"",
+							"// Compare the results with the real spark call",
+							"let sparkIds = [postman.getEnvironmentVariable('person2_id')];",
+							"let emulatorIds = [postman.getEnvironmentVariable('emulator_person2_id')];",
+							"console.log(sparkIds);",
+							"",
+							"eval(globals.compareMessageElements)(JSON.parse(responseBody), sparkIds, emulatorIds);",
+							"",
+							"    ",
+							"",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_emulatorRoom}}\",\r\n  \"markdown\" : \"<@personId:{{emulator_person2_id}}|Made up name> This is a mention for JP, aka Made up Name\"\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/messages",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Spark markdown message with two personId mentions",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "f89f6dda-12fc-48a1-a9f5-00e012cb57d3",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message with two people Spark\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getMessageElements)(JSON.parse(responseBody));",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_room}}\",\r\n  \"markdown\" : \"<@personId:{{tester_id}}|JP>, <@personId:{{person2_id}}|Another person>, This is a mention for JP and another person\"\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator markdown message with two personId mentions",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "0f4367d7-63fc-4632-b285-8e811c3a93d9",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message with two people Emulator\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"let sparkIds = [postman.getEnvironmentVariable('tester_id'), postman.getEnvironmentVariable('person2_id')];",
+							"let emulatorIds = [postman.getEnvironmentVariable('emulator_id'), postman.getEnvironmentVariable('emulator_person2_id')];",
+							"eval(globals.compareMessageElements)(JSON.parse(responseBody), sparkIds, emulatorIds);",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_emulatorRoom}}\",\r\n  \"markdown\" : \"<@personId:{{emulator_id}}|JP>, <@personId:{{emulator_person2_id}}|Another person>, This is a mention for JP and another person\"\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/messages",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Create a markdown message with a mention",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "d5581fb1-a389-4fff-9818-8a5aae927f59",
+						"type": "text/javascript",
+						"exec": [
+							"// Run the common tests for the create room request",
+							"eval(globals.commonTests)(\"Markdown message with mention in Spark\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getHeaders)();",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.getMessageElements)(JSON.parse(responseBody));",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_room}}\",\r\n  \"markdown\" : \"# Message Formatting!\\nSpark clients now render rich text; enabling bots and integrations to communicate business data in a way that's fun to read and easy on the eyes!\\n\\n## Styling Text\\nMessages are styled using [Markdown](https://daringfireball.net/projects/markdown/syntax) syntax allowing text to be emphasized in **bold**, *italics* on `in-line code`.\\n\\n### Fenced Code Blocks\\nSpark can now also render fenced code blocks using triple backticks (aka GitHub Flavored Markdown)\\n\\n```\\nsource 'https://github.com/CocoaPods/Specs.git'\\nplatform :ios, '8.0'\\nuse_frameworks!\\n\\npost_install do |installer|\\n  installer.pods_project.targets.each do |target|\\n    target.build_configurations.each do |config|\\n      config.build_settings['ENABLE_BITCODE'] = 'NO'\\n    end\\n  end\\nend\\n\\ntarget 'SparkBnB' do\\n  pod 'SparkSDK', :path => '../'\\n  pod 'Toast-Swift', '~> 1.1.0'\\nend\\n```\\n\\n### Lists\\n\\nLists are a great way to organize information or present options to your audience.\\n\\nOrderd Lists\\n1. List Item\\n2. List Item\\n3. List Item\\n\\nUnordered Lists\\n* List Item\\n* List Item\\n* List Item\\n\\n### Block Quotes\\n\\n> Quoting is a super powerful way for bots to respond to a message that happened a while back in the conversation.   And here is a mention for <@personId:{{person2_id}}|JP>.  Hope you like it\"\r\n}"
+				},
+				"url": {
+					"raw": "{{API_URL}}/messages",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator Create a markdown message with a mention",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "571e2b37-01d6-49f0-bb17-7494ad617a7d",
+						"type": "text/javascript",
+						"exec": [
+							"eval(globals.commonTests)(\"Mention message with mention Emulator\", 200);",
+							"// Collect the headers from the real Spark call",
+							"eval(globals.compareHeaders)();",
+							"// Compare the results with the real spark call",
+							"let sparkIds = [postman.getEnvironmentVariable('person2_id')];",
+							"let emulatorIds = [postman.getEnvironmentVariable('emulator_person2_id')];",
+							"console.log(sparkIds);",
+							"",
+							"eval(globals.compareMessageElements)(JSON.parse(responseBody), sparkIds, emulatorIds);",
+							"    ",
+							"    ",
+							"    ",
+							""
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "POST",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{\r\n  \"roomId\" : \"{{_emulatorRoom}}\",\r\n  \"markdown\" : \"# Message Formatting!\\nSpark clients now render rich text; enabling bots and integrations to communicate business data in a way that's fun to read and easy on the eyes!\\n\\n## Styling Text\\nMessages are styled using [Markdown](https://daringfireball.net/projects/markdown/syntax) syntax allowing text to be emphasized in **bold**, *italics* on `in-line code`.\\n\\n### Fenced Code Blocks\\nSpark can now also render fenced code blocks using triple backticks (aka GitHub Flavored Markdown)\\n\\n```\\nsource 'https://github.com/CocoaPods/Specs.git'\\nplatform :ios, '8.0'\\nuse_frameworks!\\n\\npost_install do |installer|\\n  installer.pods_project.targets.each do |target|\\n    target.build_configurations.each do |config|\\n      config.build_settings['ENABLE_BITCODE'] = 'NO'\\n    end\\n  end\\nend\\n\\ntarget 'SparkBnB' do\\n  pod 'SparkSDK', :path => '../'\\n  pod 'Toast-Swift', '~> 1.1.0'\\nend\\n```\\n\\n### Lists\\n\\nLists are a great way to organize information or present options to your audience.\\n\\nOrderd Lists\\n1. List Item\\n2. List Item\\n3. List Item\\n\\nUnordered Lists\\n* List Item\\n* List Item\\n* List Item\\n\\n### Block Quotes\\n\\n> Quoting is a super powerful way for bots to respond to a message that happened a while back in the conversation.   And here is a mention for <@personId:{{emulator_person2_id}}|JP>.  Hope you like it\"\r\n}"
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/messages",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"messages"
+					]
+				},
+				"description": "Posts a plain text or markdown message, and optionally, a media content attachment, to a room.\n\nTo get more info about message formatting, check https://developer.ciscospark.com/formatting-messages.html\n\nhttps://developer.ciscospark.com/endpoint-messages-post.html\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Delete group room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "52416ba1-bb5f-4969-932a-2d0461b2a2a1",
+						"type": "text/javascript",
+						"exec": [
+							"if (responseCode.code != 204) {",
+							"    tests[\"Delete a room: failed\"] = false",
+							"}",
+							"else {",
+							"    tests[\"Delete a room: success\"] = true",
+							"}"
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{spark_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{API_URL}}/rooms/{{_room}}",
+					"host": [
+						"{{API_URL}}"
+					],
+					"path": [
+						"rooms",
+						"{{_room}}"
+					]
+				},
+				"description": "Deletes the space that we have been working in.\r\n\r\n"
+			},
+			"response": []
+		},
+		{
+			"name": "Emulator Delete group room",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"id": "52416ba1-bb5f-4969-932a-2d0461b2a2a1",
+						"type": "text/javascript",
+						"exec": [
+							"if (responseCode.code != 204) {",
+							"    tests[\"Delete a room: failed\"] = false",
+							"}",
+							"else {",
+							"    tests[\"Delete a room: success\"] = true",
+							"}"
+						]
+					}
+				}
+			],
+			"request": {
+				"method": "DELETE",
+				"header": [
+					{
+						"key": "Authorization",
+						"value": "Bearer {{emulator_token}}"
+					},
+					{
+						"key": "Content-Type",
+						"value": "application/json"
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": ""
+				},
+				"url": {
+					"raw": "{{EMULATOR_URL}}/rooms/{{_emulatorRoom}}",
+					"host": [
+						"{{EMULATOR_URL}}"
+					],
+					"path": [
+						"rooms",
+						"{{_emulatorRoom}}"
+					]
+				},
+				"description": "Deletes the space that we have been working in.\r\n\r\n"
+			},
+			"response": []
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "618382d1-39b1-443b-a6a3-41e0ca70d2fa",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "739f359c-8dde-4baa-b96b-653d40a1a4a8",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	]
+}

--- a/test-cases/README.md
+++ b/test-cases/README.md
@@ -1,0 +1,96 @@
+# spark emulator test
+This directory includes tests that attempt to validate that the spark emulator's behavior matches the behavior of the actual Cisco Spark platform.
+
+At the time of this writing there are only test cases to validate responses to the /messages API when markdown is provided as input, as these test cases were developed while the markdown functionality was added.  It is hoped that as other contributions are made to add additional functionality to the emulator, that new test cases will be added as well.
+
+## Checklist (absolute bare minimum to run the tests)
+
+Prerequisites:
+
+The test cases make calls to both the "real" Cisco Spark platform as well as to a running instance of the emulator.   In order to call the Cisco Spark platform the tester must:
+
+- [ ] Sign up for Cisco Spark (logged in with your web browser)
+- [ ] Know the spark authentication token, person ID, display name, nickname and email associated with your spark user account
+- [ ] Know the person ID, display name, nickname and email associated with one other Spark user
+
+In addition to being able to call Spark, the tests will call a running instance of the emulator which requires:
+
+- [ ] A running instance of the spark emulator and access to the tokens.json file that defines the valid users for the emulator
+
+The tests were creating using Postman, a tool for making API calls available here:https://www.getpostman.com/.   The test cases were developed using tips from this blogpost: http://blog.getpostman.com/2017/07/28/api-testing-tips-from-a-postman-professional/
+
+## Configuruing the Postman environment
+
+Before running the tests, you must configure your environment with the details of your Spark Test users.  Make a copy of the file [spark_emulator_tests.postman_environment_starter.json](./spark_emulator_tests.postman_environment_starter.json), rename it spark_emulator_tests.postman_environment.json and open it with your favorite editor.  Alternately, you can import this file into postman and edit the environment there.  
+
+This environment file defines the environment variables required for the tests.   The API_URL is pre-populated.  You must manually update the enivronment to specify the following environment variables below:
+* API_URL -- The URL of the live Spark API
+* spark_token -- A valid auth token for calling Spark
+* tester_id -- the person ID of the holder of spark_token
+* tester_display_name -- the display name of the holder of spark_token
+* tester_nickname -- the nickname of the holder of the spark_token
+* tester_email -- the email of the holder of the spark_token
+* person2_id: -- the person ID of a second person that can be added to the spark room
+* person2_email - the spark email for the second person
+* person2_display_name - the second person's spark display name
+* person2_nickname -- the second person's nickname
+
+These variables for the emulator environment are pre-populated using the default values for this project and with values specified in [tokens.json](./tokens.json).   As you customize the spark-emulator for your enviroment you may also need to update these test enviroment variables as well.
+
+* EMULATOR_URL - The URL of the Spark Emulator being tested
+* emulator_token - The token of a user specified in the emulator's token.json file
+* emulator_display_name - The display name associated with that user in token.json
+* emulator_nickname - The nickname associated with that user in token.json
+* emulator_id - The person ID associated with that user in token.json
+* emulator_email - The email associated with that user in token.json
+* emulator_person2_id The person ID of a second user defined in the emulator's token.json file
+* emulator_person2_email: - The email associated with that user in token.json
+* emulator_person2_display_name - The display name associated with that user in token.json
+* emulator_person2_nickname - The nickname associated with that user in token.json
+
+Once your copy of the environment variables are specified you can run the tests from the command line or load the provided test cases and postman environment into your Postman instance by choosing Import from the File Menu and import the two files [CiscoSparkMarkdownTests.postman_collection.json](./CiscoSparkMarkdownTests.postman_collection.json), and [spark_emulator_tests.postman_environment.json](./spark_emulator_tests.postman_environment.json).  
+
+## Running the tests
+The NPM commands in this section should be run from the spark-emulator project diretory.
+
+To run the tests from the command line, you will need to have Postman's cli tool: newman installed.   If you do not have this install it as follows:
+    
+    npm install -g newman
+
+Before running the tests, start the emulator:
+
+    npm start
+
+Finally, run the test cases:
+
+    npm test
+
+Alternately, you may choose to run the tests from within the Postman tool either manually, or using the Runner tool.    For this collection of test cases the order is important in general, the following methodology is used:
+* First test creates a room in spark and defines many of the functions used by subsequent test cases.  *It is important that this test be run before any other tests are run.*   In postman view the Tests tab better understand what the test cases do
+* The second test creates a room in the emulator
+* After these, the test cases generally send a message to the Spark environment, save the results, and then send the same message (although with different user IDs when sending markdown that includes mentions), and compares the results.
+* The final two tests delete the spaces in both the real Spark environment and in the emulator
+
+
+When properly configured almost all test will pass with the following exceptions:
+* The test that excersises a mention using the <@personId:[id]|[name]> syntax with an invalid ID fails.  On the real spark platform the invalid ID is replaced with some encoded version of the invalid ID while in the emulator the markdown and html include the ID that was passed in.  In addition the emulator will pass the invalid IDs back in the mentionedPeople array while Spark does not. It is expected that three out of the seven test cases will fail. 
+* The test that excersises a mention using the <@personEmail:[email]|[name]> syntax fails.  As of this writing performing functions such as adding users to spaces via email, or mentioning users via email is not supported in the emulator.   It is expected that four out of the seven test will fail.
+
+When running the tests from the command line succesful output will be:
+┌─────────────────────────┬──────────┬──────────┐
+│                         │ executed │   failed │
+├─────────────────────────┼──────────┼──────────┤
+│              iterations │        1 │        0 │
+├─────────────────────────┼──────────┼──────────┤
+│                requests │       22 │        0 │
+├─────────────────────────┼──────────┼──────────┤
+│            test-scripts │       22 │        0 │
+├─────────────────────────┼──────────┼──────────┤
+│      prerequest-scripts │        0 │        0 │
+├─────────────────────────┼──────────┼──────────┤
+│              assertions │       85 │        7 │
+├─────────────────────────┴──────────┴──────────┤
+
+
+
+- [ ] Turn on your bot server with ```npm start```

--- a/test-cases/spark_emulator_tests.postman_environment_starter.json
+++ b/test-cases/spark_emulator_tests.postman_environment_starter.json
@@ -1,0 +1,129 @@
+{
+  "id": "0dc4a5b2-cc50-4ea6-9dd7-5af639c840be",
+  "name": "spark_emulator_tests",
+  "values": [
+    {
+      "key": "API_URL",
+      "value": "https://api.ciscospark.com/v1",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "spark_token",
+      "value": "[YOUR_TOKEN_HERE]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "tester_id",
+      "value": "[ID_OF_USER_WITH_PROVIDED_TOKEN]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "tester_display_name",
+      "value": "[DISPLAY_NAME_OF_USER_WITH_PROVIDED_TOKEN]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "tester_nickname",
+      "value": "[NICKNAME_OF_USER_WITH_PROVIDED_TOKEN]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "tester_email",
+      "value": "[EMAIL_OF_USER_WITH_PROVIDED_TOKEN]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "person2_id",
+      "value": "[ID_OF_A_SECOND_SPARK_USER]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "person2_email",
+      "value": "[EMAIL_OF_A_SECOND_SPARK_USER]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "person2_display_name",
+      "value": "[DISPLAY_NAME_OF_A_SECOND_SPARK_USER]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "person2_nickname",
+      "value": "[NICKNAME_OF_A_SECOND_SPARK_USER]",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "EMULATOR_URL",
+      "value": "http://localhost:3210",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_token",
+      "value": "01234567890123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_display_name",
+      "value": "Mr. Postman",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_nickname",
+      "value": "Posty",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_id",
+      "value": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS85MmIzZGQ5YS02NzVkLTRhNDEtOGM0MS0yYWJkZjg5ZjQ0ZjR",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_email",
+      "value": "postman-test@cisco.com",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_person2_id",
+      "value": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS85MmIzZGQ5YS02NzVkLTRhNDEtOGM0MS0yYWJkZjg5ZjQ0ZjQ",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_person2_email",
+      "value": "stsfartz@cisco.com",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_person2_display_name",
+      "value": "Stève Sfartz",
+      "type": "text",
+      "enabled": true
+    },
+    {
+      "key": "emulator_person2_nickname",
+      "value": "Stève",
+      "type": "text",
+      "enabled": true
+    }
+  ],
+  "_postman_variable_scope": "environment",
+  "_postman_exported_at": "2018-03-30T21:28:01.159Z",
+  "_postman_exported_using": "Postman/6.0.9"
+}

--- a/tokens.json
+++ b/tokens.json
@@ -28,7 +28,7 @@
         "type": "bot"
     },
     "01234567890123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ": {
-        "id": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS85MmIzZGQ5YS02NzVkLTRhNDEtOGM0MS0yYWJkZjg5ZjQ0ZjQ",
+        "id": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS85MmIzZGQ5YS02NzVkLTRhNDEtOGM0MS0yYWJkZjg5ZjQ0ZjR",
         "emails": [
             "postman-test@cisco.com"
         ],

--- a/tokens.json
+++ b/tokens.json
@@ -26,5 +26,19 @@
         "orgId": "Y2lzY29zcGFyazovL3VzL09SR0FOSVpBVElPTi8xZWI2NWZkZi05NjQzLTQxN2YtOTk3NC1hZDcyY2FlMGUxMGY",
         "created": "2017-07-18T00:00:00.000Z",
         "type": "bot"
+    },
+    "01234567890123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ": {
+        "id": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS85MmIzZGQ5YS02NzVkLTRhNDEtOGM0MS0yYWJkZjg5ZjQ0ZjQ",
+        "emails": [
+            "postman-test@cisco.com"
+        ],
+        "displayName": "Mr. Postman",
+        "nickName": "Posty",
+        "firstName": "Post",
+        "lastName": "Man",
+        "avatar": "https://cdn-images-1.medium.com/max/1600/1*Iel5Q6qAxgBdl_IHUx3scA.jpeg",
+        "orgId": "Y2lzY29zcGFyazovL3VzL09SR0FOSVpBVElPTi8xZWI2NWZkZi05NjQzLTQxN2YtOTk3NC1hZDcyY2FlMGUxMGY",
+        "created": "2017-07-18T00:00:00.000Z",
+        "type": "person"
     }
 }

--- a/utils.js
+++ b/utils.js
@@ -83,7 +83,10 @@ utils.sendSuccess = function (res, statusCode, body) {
         return;
     }
 
-    res.status(statusCode).send(body);
+    // Send as new buffer to override express auto setting of Content-Type header
+    // We set this manually since Spark does not include a space, ie:
+    // "Content-type": "application/json;charset=UTF-8"
+    res.status(statusCode).send(new Buffer(JSON.stringify(body)));
 }
 
 


### PR DESCRIPTION
Added code to support markdown in messages.   This is particularly needed in order to test bots in group spaces when the bot will only respond to commands where the bot is mentioned.    

This commit also includes a set of postman based tests that sends markdown messages to the Spark platform and to the emulator and compares the return values.